### PR TITLE
Use tailwind container instead of fixed widths

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -34,6 +34,16 @@ module.exports = {
         },
       },
     },
+    container: {
+        padding: {
+          DEFAULT: '1rem',
+          sm: '2rem',
+          md: '2rem',
+          lg: '4rem',
+          xl: '5rem',
+          '2xl': '6rem',
+        },
+      },
   },
   plugins: [
     require("@tailwindcss/forms"),

--- a/lib/threat_shield_web/components/breadcrumbs.ex
+++ b/lib/threat_shield_web/components/breadcrumbs.ex
@@ -10,7 +10,7 @@ defmodule ThreatShieldWeb.Breadcrumbs do
     assigns = assign(assigns, :size, length(assigns.breadcrumbs))
 
     ~H"""
-    <nav class="flex text-gray-500 text-sm font-medium mb-2" aria-label="breadcrumb">
+    <nav class="flex text-gray-500 text-sm font-medium m-4" aria-label="breadcrumb">
       <ol class="inline-flex items-center space-x-1 md:space-x-3">
         <.breadcrumb_item
           :for={{breadcrumb, index} <- Enum.with_index(@breadcrumbs)}

--- a/lib/threat_shield_web/components/core_components.ex
+++ b/lib/threat_shield_web/components/core_components.ex
@@ -874,7 +874,7 @@ defmodule ThreatShieldWeb.CoreComponents do
 
   def card_detail_org(assigns) do
     ~H"""
-    <section class="w-[1068px] px-8 py-6 mb-6 bg-white rounded-lg shadow flex-col justify-start items-start inline-flex">
+    <section class="w-full px-8 py-6 mb-6 bg-white rounded-lg shadow flex-col justify-start items-start inline-flex">
       <div class="flex justify-between w-full pb-6 border-b border-gray-200">
         <div class="h-20 pb-5">
           <.h3>

--- a/lib/threat_shield_web/components/layouts/app.html.heex
+++ b/lib/threat_shield_web/components/layouts/app.html.heex
@@ -1,11 +1,15 @@
 <header>
-  <.navbar organisation={assigns[:organisation]} current_user={assigns[:current_user]} entity_page={assigns[:entity_page]}/>
+  <.navbar
+    organisation={assigns[:organisation]}
+    current_user={assigns[:current_user]}
+    entity_page={assigns[:entity_page]}
+  />
 </header>
-<main class="absolute left-[222px] mt-10 w-[1068px]">
-    <%= if assigns[:breadcrumbs] do %>
-      <ThreatShieldWeb.Breadcrumbs.breadcrumb breadcrumbs={@breadcrumbs} context={assigns} />
-    <% end %>
- 
+<main class="xl:container mx-4 xl:mx-auto mb-10">
+  <%= if assigns[:breadcrumbs] do %>
+    <ThreatShieldWeb.Breadcrumbs.breadcrumb breadcrumbs={@breadcrumbs} context={assigns} />
+  <% end %>
+
   <div class="mx-auto">
     <.flash_group flash={@flash} />
     <%= @inner_content %>


### PR DESCRIPTION
Hey, 

here is a small PR for a minor layout change. There was a fixed width set, that seems to fit only specific screen sizes. But on most screens the content was not centered but shifted to the left. I changed this to tailwind containers and adapted some margins. 
Maybe you already had other plans, than of course feel free to discard this PR :-)

